### PR TITLE
Remove vagababov as Scaling WG lead

### DIFF
--- a/working-groups/WORKING-GROUPS.md
+++ b/working-groups/WORKING-GROUPS.md
@@ -302,7 +302,10 @@ Autoscaling behavior of Knative Serving
 | &nbsp;                                                         | Leads           | Company | Profile                                             |
 | -------------------------------------------------------------- | --------------- | ------- | --------------------------------------------------- |
 | <img width="30px" src="https://github.com/markusthoemmes.png"> | Markus Thömmes  | Red Hat | [markusthoemmes](https://github.com/markusthoemmes) |
-| <img width="30px" src="https://github.com/vagababov.png">      | Victor Agababov | Google  | [vagababov](https://github.com/vagababov)           |
+
+| &nbsp;                                                  | Emeritus Leads  | Profile                               | Duration  |
+| --------------------------------------------------------| --------------- | --------------------------------------| --------- |
+| <img width="30px" src="https://github.com/vagababov.png"> | Victor Agababov |  [vagababov](https://github.com/vagababov) | 2019-2021 |
 
 ## Security
 


### PR DESCRIPTION
After changing teams and furthermore after 2.5 months of parental leave,
I just don't feel like I can contribute at the level this position
requires.

It's been a please and an honor serving in this position.

I will be still be around, still review code, and what not, but it's
120% project, than a full time job for me now.

Sorry, Markus, than I am increasing your workload, though probably temporarily :-)

Thanks, yours truly.